### PR TITLE
🔨 use --development flag for sample app build to avoid minification

### DIFF
--- a/sample-app/package.json
+++ b/sample-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build --mode development",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
Our previous changes in #6 worked insofar as netlify started deploying but unfortunately the standard build, which attempts to minimise all three gajillon FHIR validation scripts, takes so long it eventually times out. [After some research](https://forum.vuejs.org/t/vue-cli-build-without-minification/36234), this seems like the best way to get around build minification. It's not as smooth as a proper "skip minification for _just these files_" approach, but given the limited scope of the sample app AND the complexity of webpack fidgeting, I'd argue it's a working solution.